### PR TITLE
Add thumbs up and thumbs down icon and validation for empty rating

### DIFF
--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -100,4 +100,3 @@ a.body-link:hover {
 .alert-error {
   color: red;
 }
-

--- a/app/controllers/ratings_controller.rb
+++ b/app/controllers/ratings_controller.rb
@@ -12,6 +12,8 @@ class RatingsController < ApplicationController
       review_rating = ReviewRating.create(review_id: rating_params[:review_id],
                                           rating_id: rating.id)
       redirect_to review_path(rating_params[:review_id])
+    else
+      redirect_to new_rating_path(rating_params[:review_id]), { flash: { error: "Please select a button" } }
     end
   end
 

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -1,4 +1,6 @@
 class Rating < ApplicationRecord
+  validates :helpful, inclusion: { in: [true, false] }
+
   has_one :review_rating
   has_one :review, through: :review_rating
 end

--- a/app/models/rating_check.rb
+++ b/app/models/rating_check.rb
@@ -1,6 +1,0 @@
-class RatingCheck < ApplicationRecord
-  validates :category, presence: true
-  validates :value, inclusion: { in: [true, false] }
-
-  belongs_to :rating
-end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= stylesheet_link_tag    'https://fonts.googleapis.com/css?family=Cutive' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <script src="https://use.fontawesome.com/c416b7395a.js"></script>
   </head>
 
   <body>

--- a/app/views/ratings/new.html.erb
+++ b/app/views/ratings/new.html.erb
@@ -1,11 +1,25 @@
-<%= @review.content %>
+<h2>Rate review</h2>
+
+<p><span class='carrot'>></span> <%= @review.content %></p><br />
+
+<p>Is this review kind, specific, and actionable?</p><br />
+
+<% if flash[:error] %>
+  <div class = "alert-error"><%= flash[:error] %><br /><br /></div>
+<% end %>
 
 <%= form_tag("/ratings", method: "post") do %>
   <%= fields_for :rating do |f| %>
     <%= f.radio_button(:helpful, true) %>
-    <%= f.label(:helpful_true, "helpful") %><br />
+    <%= f.label :helpful_true do %>
+      <i class="fa fa-thumbs-up" aria-hidden="true"></i>
+    <% end %>
+
     <%= f.radio_button(:helpful, false) %>
-    <%= f.label(:kind_false, "unhelpful") %><br /><br />
+    <%= f.label :helpful_false do %>
+      <i class="fa fa-thumbs-down" aria-hidden="true"></i>
+    <% end %>
+    <br /><br />
 
     <%= f.hidden_field :review_id, value: @review.id %>
 

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -1,8 +1,20 @@
-<%= @review.content %>
-<br />
+<h2>Review</h2>
 
-<% @ratings.each do |rating| %>
-  Kind, specific, actionable: <%= rating.helpful %><br />
-<% end %>
+<p><span class="carrot">></span> <%= @review.content %></p><br />
 
 <%= link_to "Rate review", new_rating_path(@review) %>
+<br /><br />
+
+<hr>
+
+<h3>Previous ratings</h3>
+
+<p>Was this review kind, specific, and actionable?</p><br />
+<% @ratings.each do |rating| %>
+  <% if rating.helpful %>
+    <i class="fa fa-thumbs-up" aria-hidden="true"></i>
+  <% else %>
+    <i class="fa fa-thumbs-down" aria-hidden="true"></i>
+  <% end %>
+  <br />
+<% end %>

--- a/spec/controllers/ratings_controller_spec.rb
+++ b/spec/controllers/ratings_controller_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe RatingsController, :type => :controller do
       get :new, params: { format: review.id }
 
       expect(response.body).to include(review.content)
+      expect(response.body).to include("Is this review kind, specific, and actionable?")
     end
   end
 
@@ -21,6 +22,15 @@ RSpec.describe RatingsController, :type => :controller do
 
       expect(response).to redirect_to(review)
       expect(response).to have_http_status(:redirect)
+    end
+
+    it 'displays flash message if radio button not selected' do
+      review = create(:review, content: "Java Server")
+
+      post :create, params: { rating: { helpful: nil, review_id: review.id } }
+
+      expect(response).to redirect_to(new_rating_path(review))
+      expect(flash[:error]). to match("Please select a button")
     end
   end
 end

--- a/spec/integration/rating_spec.rb
+++ b/spec/integration/rating_spec.rb
@@ -9,7 +9,16 @@ describe 'rating', :type => :feature do
       choose('rating_helpful_true')
       click_button('Rate review')
 
-      expect(page).to have_content("Kind, specific, actionable: true")
+      expect(page).to have_xpath('//i', :class => 'fa fa-thumbs-up')
+    end
+
+    it 'displays error message if radio button not selected' do
+      review = create(:review, content: 'This looks really good!')
+
+      visit new_rating_path(review)
+      click_button('Rate review')
+
+      expect(page).to have_content("Please select a button")
     end
   end
 

--- a/spec/integration/review_spec.rb
+++ b/spec/integration/review_spec.rb
@@ -11,7 +11,7 @@ describe 'review', :type => :feature do
       visit '/reviews/' + review.id.to_s
 
       expect(page).to have_content(review.content)
-      expect(page).to have_content('Kind, specific, actionable: true')
+      expect(page).to have_xpath('//i', :class => 'fa fa-thumbs-up')
     end
   end
 

--- a/spec/models/rating_spec.rb
+++ b/spec/models/rating_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe Rating do
 
     expect(rating.helpful).to eq(true)
   end
+
   it' does not save if helpful field is not set' do
-    rating = Rating.new()
+    rating = Rating.new(helpful: nil)
 
     expect(rating.id).to eq(nil)
   end


### PR DESCRIPTION
Review show page and rating new page both show thumbs up and thumbs down icons for the `helpful` boolean field.

Rating new page shows flash notification when you fail to select either thumbs up or thumbs down.

Also deletes a model class that is no longer being used.

Closes story 7.