### PR TITLE
Add text field to ratings and appropriate validation

### DIFF
--- a/app/controllers/ratings_controller.rb
+++ b/app/controllers/ratings_controller.rb
@@ -7,20 +7,25 @@ class RatingsController < ApplicationController
   end
 
   def create
-    rating = Rating.new(helpful: rating_params[:helpful])
+    rating = Rating.new(helpful: rating_params[:helpful],
+                        explanation: rating_params[:explanation])
     if rating.save
       review_rating = ReviewRating.create(review_id: rating_params[:review_id],
                                           rating_id: rating.id)
       redirect_to review_path(rating_params[:review_id])
     else
-      redirect_to new_rating_path(rating_params[:review_id]), { flash: { error: "Please select a button" } }
+      if rating.helpful == false and rating.explanation.blank?
+        redirect_to new_rating_path(rating_params[:review_id]), { flash: { error: "Please provide an explanation" } }
+      else
+        redirect_to new_rating_path(rating_params[:review_id]), { flash: { error: "Please select a button" } }
+      end
     end
   end
 
   private
 
   def rating_params
-    params.require(:rating).permit(:helpful, :review_id)
+    params.require(:rating).permit(:helpful, :explanation, :review_id)
   end
 
   def require_review

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -1,6 +1,12 @@
 class Rating < ApplicationRecord
   validates :helpful, inclusion: { in: [true, false] }
+  validates :explanation, presence: true, if: :unhelpful?
 
   has_one :review_rating
   has_one :review, through: :review_rating
+
+  def unhelpful?
+    helpful == false
+  end
+
 end

--- a/app/views/ratings/new.html.erb
+++ b/app/views/ratings/new.html.erb
@@ -2,27 +2,34 @@
 
 <p><span class='carrot'>></span> <%= @review.content %></p><br />
 
-<p>Is this review kind, specific, and actionable?</p><br />
+<p>Is this review kind, specific, and actionable? If your answer is no, then explain why.</p><br />
 
 <% if flash[:error] %>
-  <div class = "alert-error"><%= flash[:error] %><br /><br /></div>
+  <div class = "alert-error"><%= flash[:error] %><br /></div>
 <% end %>
 
 <%= form_tag("/ratings", method: "post") do %>
   <%= fields_for :rating do |f| %>
-    <%= f.radio_button(:helpful, true) %>
-    <%= f.label :helpful_true do %>
-      <i class="fa fa-thumbs-up" aria-hidden="true"></i>
-    <% end %>
+    <div class='big-box'>
+      <%= f.radio_button(:helpful, true) %>
+      <%= f.label :helpful_true do %>
+        <i class="fa fa-thumbs-up" aria-hidden="true"></i>
+      <% end %>
 
-    <%= f.radio_button(:helpful, false) %>
-    <%= f.label :helpful_false do %>
-      <i class="fa fa-thumbs-down" aria-hidden="true"></i>
-    <% end %>
-    <br /><br />
+      <%= f.radio_button(:helpful, false) %>
+      <%= f.label :helpful_false do %>
+        <i class="fa fa-thumbs-down" aria-hidden="true"></i>
+      <% end %>
+      <br /><br />
 
-    <%= f.hidden_field :review_id, value: @review.id %>
+      <div class='large-content-field'>
+        <%= f.label :explanation, "Explanation:" %><br /><br />
+        <%= f.text_area(:explanation, cols: 90, rows: 16, style: 'padding: 10px; font-size 1.25em;') %>
+      </div>
 
-    <%= f.submit("Rate review") %>
+      <%= f.hidden_field :review_id, value: @review.id %>
+
+      <%= f.submit("Rate review") %>
+    </div>
   <% end %>
 <% end %>

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -16,5 +16,6 @@
   <% else %>
     <i class="fa fa-thumbs-down" aria-hidden="true"></i>
   <% end %>
+  <%= rating.explanation %>
   <br />
 <% end %>

--- a/db/migrate/20161024195631_change_ratings.rb
+++ b/db/migrate/20161024195631_change_ratings.rb
@@ -1,0 +1,7 @@
+class ChangeRatings < ActiveRecord::Migration[5.0]
+  def change
+    change_table :ratings do |t|
+      t.string :explanation
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161024160542) do
+ActiveRecord::Schema.define(version: 20161024195631) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,9 +32,10 @@ ActiveRecord::Schema.define(version: 20161024160542) do
   end
 
   create_table "ratings", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
     t.boolean  "helpful"
+    t.string   "explanation"
   end
 
   create_table "review_ratings", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,7 +18,7 @@ schmooze =  ['I worked really hard on this project',
             'The fact that you are taking time out of your busy, busy day means so very much to me', 
             'This is the first time I have had the opportunity to work with this technology']
 
-userNames = ['barakobama', 'hillaryclinton', 'donaldtrump', 'berniesanders', 'tedcruz', 'jebbush', 'marcorubio', 'lincolnchafee',
+userNames = ['barackobama', 'hillaryclinton', 'donaldtrump', 'berniesanders', 'tedcruz', 'jebbush', 'marcorubio', 'lincolnchafee',
              'martinomalley', 'jimwebb', 'ricksantorum', 'scottwalker', 'chrischristie', 'bencarson']
 
 content = [ 'This looks great', 
@@ -44,7 +44,17 @@ content = [ 'This looks great',
             'The way that this is written, it violates the Interface Segregation Principle. I would fix this if I were you.',
             'This looks really great. It is obvious that you are really considering your SOLID principles here']
 
-rand_bool = [true, false].sample
+thumbs_up = [ '',
+              'This is a good review',
+              'This is a great review']
+
+thumbs_down = [ 'This is not kind',
+                'This is not specific',
+                'This is not actionable',
+                'This is neither kind nor specific',
+                'This is neither specific nor actionable',
+                'This is neither kind nor actionable',
+                'This is neither kind, specific, or actionable' ]
 
 titles = []
 
@@ -70,7 +80,12 @@ content.each do |content|
 end
 
 20.times do
-  Rating.create(helpful: rand_bool)
+  rand_bool = rand(2)
+  if rand_bool == 1
+    Rating.create(helpful: true, explanation: thumbs_up.sample)
+  else
+    Rating.create(helpful: false, explanation: thumbs_down.sample) 
+  end
 end
 
 45.times do

--- a/spec/controllers/ratings_controller_spec.rb
+++ b/spec/controllers/ratings_controller_spec.rb
@@ -32,5 +32,16 @@ RSpec.describe RatingsController, :type => :controller do
       expect(response).to redirect_to(new_rating_path(review))
       expect(flash[:error]). to match("Please select a button")
     end
+
+    it 'displays flash message if helpful is set to false and explanation is blank' do
+      review = create(:review, content: "Java Server")
+
+      post :create, params: { rating: { helpful: false,
+                                        explanation: '',
+                                        review_id: review.id } }
+
+      expect(response).to redirect_to(new_rating_path(review))
+      expect(flash[:error]). to match("Please provide an explanation")
+    end
   end
 end

--- a/spec/factories/ratings.rb
+++ b/spec/factories/ratings.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
   factory :rating do
-    helpful false
+    helpful true
   end
 end

--- a/spec/integration/rating_spec.rb
+++ b/spec/integration/rating_spec.rb
@@ -20,6 +20,29 @@ describe 'rating', :type => :feature do
 
       expect(page).to have_content("Please select a button")
     end
+
+    it 'displays error message if rated not helpful without any explanation' do
+      review = create(:review, content: 'This looks really good!')
+
+      visit new_rating_path(review)
+      choose('rating_helpful_false')
+      click_button('Rate review')
+
+      expect(page).to have_content("Please provide an explanation")
+    end
+
+    it 'creates new rating if rated not helpful and explanation provided' do
+      review = create(:review, content: 'This looks really good!')
+      explanation = 'Need to be more specific'
+
+      visit new_rating_path(review)
+      choose('rating_helpful_false')
+      fill_in('rating_explanation', :with => explanation)
+      click_button('Rate review')
+
+      expect(page).to have_xpath('//i', :class => 'fa fa-thumbs-down')
+      expect(page).to have_content(explanation)
+    end
   end
 
   describe 'if not from a review page' do

--- a/spec/models/rating_spec.rb
+++ b/spec/models/rating_spec.rb
@@ -7,9 +7,24 @@ RSpec.describe Rating do
     expect(rating.helpful).to eq(true)
   end
 
-  it' does not save if helpful field is not set' do
-    rating = Rating.new(helpful: nil)
+  it 'does not save if helpful field is not set' do
+    rating = Rating.create(helpful: nil)
 
+    expect(rating.id).to eq(nil)
+  end
+
+  it 'has an explanation field that can be set' do
+    explanation = 'This review is not kind, specific, or actionable.'
+    rating = Rating.new(helpful: false,
+                        explanation: explanation) 
+
+    expect(rating.explanation).to eq(explanation)
+  end
+
+  it 'does not save if helpful is false and explanation is blank' do
+    rating = Rating.create(helpful: false,
+                        explanation: '')
+    
     expect(rating.id).to eq(nil)
   end
 end

--- a/spec/models/review_rating_spec.rb
+++ b/spec/models/review_rating_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe ReviewRating do
   it 'belongs to a review and a rating' do
     review = create(:review)
-    rating = create(:rating)
+    rating = create(:rating, helpful: true)
     review_rating = ReviewRating.new(rating_id: rating.id,
                                      review_id: review.id)
 


### PR DESCRIPTION
Add text field called `explanation` to Rating model.
Validate so that `explanation` is required if `helpful` is false but not if `helpful` is true.
Update `seeds.rb` to seed explanations for ratings.