### PR TITLE
Add functionality to create new project

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -7,4 +7,30 @@ class ProjectsController < ApplicationController
     @project = Project.find_by_id(params[:id])
     @reviews = @project.reviews
   end
+
+  def new
+    @project = Project.new
+  end
+
+  def create
+    project = Project.new(title: project_params[:title],
+                          description: project_params[:description])
+    if project.save
+      redirect_to projects_path
+    else
+      if project.title.blank? and project.description.blank?
+        redirect_to new_project_path, { flash: { error: "Please provide a title and description" } }
+      elsif project.description.blank?
+        redirect_to new_project_path, { flash: { error: "Please provide a description" } }
+      else
+        redirect_to new_project_path, { flash: { error: "Please provide a title" } }
+      end
+    end
+  end
+
+  private
+
+  def project_params
+    params.require(:project).permit(:title, :description)
+  end
 end

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -1,3 +1,11 @@
+<div>
+  <div class='mini-box'>
+    <div class='squarebrackets'>
+      <%= link_to '+ create new project', new_project_path, class: 'body-link' %><br />
+    </div>
+  </div>
+</div>
+
 <% @projects.each do |project| %>
   <div>
     <div class='mini-box'>

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -1,0 +1,18 @@
+<h2>Create new project</h2>
+
+<% if flash[:error] %>
+  <div class='alert-error'><%= flash[:error] %><br /></div>
+<% end %>
+
+<%= form_for @project do |f| %>
+  <div class='big-box'>
+    <%= f.label :title, "Title:" %>
+    <%= f.text_field :title, size: 90 %><br /><br />
+    <div class='large-content-field'>
+      <%= f.label :description, "Description:" %><br /><br />
+      <%= f.text_area(:description, cols: 90, rows: 16, style: 'padding: 10px; font-size: 1.25em;') %>
+    </div>
+
+    <%= f.submit("Create new project") %>
+  </div>
+<% end %>

--- a/app/views/ratings/new.html.erb
+++ b/app/views/ratings/new.html.erb
@@ -5,7 +5,7 @@
 <p>Is this review kind, specific, and actionable? If your answer is no, then explain why.</p><br />
 
 <% if flash[:error] %>
-  <div class = "alert-error"><%= flash[:error] %><br /></div>
+  <div class="alert-error"><%= flash[:error] %><br /></div>
 <% end %>
 
 <%= form_tag("/ratings", method: "post") do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   root 'projects#index'
 
-  resources :projects, only: [:index, :show]
-  resources :reviews, only: [:create, :new, :show]
+  resources :projects, only: [:index, :show, :new, :create]
+  resources :reviews, only: [:show, :new, :create]
   resources :ratings, only: [:new, :create]
 end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -14,6 +14,44 @@ RSpec.describe ProjectsController, :type => :controller do
       expect(response.body).to include(project1.title)
       expect(response.body).to include(project2.title)
     end
+
+    it 'includes a link to new project' do
+      get :index
+
+      expect(response.body).to include('create new project')
+    end
+  end
+
+  describe 'GET /projects/new' do
+    it 'renders the template for the project new page' do
+      get :new
+
+      expect(response.body).to include("Title")
+      expect(response.body).to include("Description")
+    end
+  end
+
+  describe 'POST /projects/new' do
+    it 'creates a new project and redirects to the project index page' do
+      post :create, params: { project: { title: 'my project', description: 'a description' } }
+
+      expect(response).to redirect_to(projects_path)
+      expect(response).to have_http_status(:redirect)
+    end
+
+    it 'displays flash message if title is blank' do
+      post :create, params: { project: { title: '', description: 'a description' } }
+
+      expect(response).to redirect_to(new_project_path)
+      expect(flash[:error]).to match("Please provide a title")
+    end
+
+    it 'displays flash message if description is blank' do
+      post :create, params: { project: { title: 'my project', description: '' } }
+
+      expect(response).to redirect_to(new_project_path)
+      expect(flash[:error]).to match("Please provide a description")
+    end
   end
 
   describe 'GET /projects/:id' do

--- a/spec/controllers/ratings_controller_spec.rb
+++ b/spec/controllers/ratings_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe RatingsController, :type => :controller do
     end
   end
 
-  describe 'POST /ratings' do
+  describe 'POST /ratings/new' do
     it 'creates a new rating and redirects to the review show page' do
       review = create(:review, content: "Java Server")
 
@@ -30,7 +30,7 @@ RSpec.describe RatingsController, :type => :controller do
       post :create, params: { rating: { helpful: nil, review_id: review.id } }
 
       expect(response).to redirect_to(new_rating_path(review))
-      expect(flash[:error]). to match("Please select a button")
+      expect(flash[:error]).to match("Please select a button")
     end
 
     it 'displays flash message if helpful is set to false and explanation is blank' do

--- a/spec/controllers/reviews_controller_spec.rb
+++ b/spec/controllers/reviews_controller_spec.rb
@@ -3,6 +3,11 @@ require 'spec_helper'
 RSpec.describe ReviewsController, :type => :controller do
   render_views
 
+  describe 'GET /reviews/new' do
+    it 'renders the template for the review new page' do
+    end
+  end
+
   describe 'POST /reviews/new' do
     it 'creates a new review and redirects to the project show page' do
       project = create(:project, title: "Java Tic-Tac-Toe", description: "TTT, you'll love it")

--- a/spec/integration/project_spec.rb
+++ b/spec/integration/project_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'project' do
-  describe 'project index page' do
+  describe 'index page' do
     it 'shows all projects as links' do
       project1 = create(:project)
       project2 = create(:project, title: "Java Tic-Tac-Toe")
@@ -11,9 +11,17 @@ describe 'project' do
       expect(page).to have_content(project1.title)
       expect(page).to have_content(project2.title)
     end
+
+    it 'navigates to new project page when link is clicked' do
+      visit "/"
+      click_link('+ create new project')
+
+      expect(page).to have_css('form')
+      expect(current_path).to eq('/projects/new')
+    end
   end
 
-  describe 'project show page' do
+  describe 'show page' do
     it 'shows the project title and description' do
       project = create(:project, title: "my title", description: "my desc")
 
@@ -31,6 +39,48 @@ describe 'project' do
       click_link('new review')
 
       expect(page).to have_css('form')
+    end
+  end
+
+  describe 'new page' do
+    it 'displays a form for a new project' do
+      visit '/projects/new'
+
+      expect(page).to have_css('form')
+      expect(page).to have_content('Create new project')
+      expect(page).to have_field('Title')
+      expect(page).to have_field('Description')
+      expect(page).to have_button('Create new project')
+    end
+
+    it 'redirects to the projects index page when a new project is submitted' do
+      visit '/projects/new'
+      fill_in('project[title]', with: 'my project')
+      fill_in('project[description]', with: 'a description')
+      click_button('Create new project')
+
+      expect(current_path).to eq('/projects')
+      expect(page).to have_content('my project')
+    end
+
+    it 'displays a warning if title is left blank when creating a new project' do
+      visit '/projects/new'
+      fill_in('project[description]', with: 'a description')
+      click_button('Create new project')
+
+      expect(current_path).to eq('/projects/new')
+      expect(page).to have_content('Create new project')
+      expect(page).to have_content('Please provide a title')
+    end
+
+    it 'displays a warning if description is left blank when creating a new project' do
+      visit '/projects/new'
+      fill_in('project[title]', with: 'my project')
+      click_button('Create new project')
+
+      expect(current_path).to eq('/projects/new')
+      expect(page).to have_content('Create new project')
+      expect(page).to have_content('Please provide a description')
     end
   end
 end

--- a/spec/integration/rating_spec.rb
+++ b/spec/integration/rating_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'rating', :type => :feature do
-  describe 'link to new rating page' do
+  describe 'new page' do
     it 'creates a new rating' do
       review = create(:review, content: 'This looks really good!')
 
@@ -43,10 +43,8 @@ describe 'rating', :type => :feature do
       expect(page).to have_xpath('//i', :class => 'fa fa-thumbs-down')
       expect(page).to have_content(explanation)
     end
-  end
 
-  describe 'if not from a review page' do
-    it 'redirects to projects show' do
+    it 'redirects to projects show if not from a review page' do
       visit new_rating_path
 
       expect(current_path).to eq(projects_path)

--- a/spec/integration/review_spec.rb
+++ b/spec/integration/review_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'review', :type => :feature do
-  describe 'show page with ratings' do
+  describe 'shows page with ratings' do
     it 'shows all ratings in a review' do
       review = create(:review, content: 'Looks good!')
       rating = create(:rating, helpful: true)
@@ -15,7 +15,7 @@ describe 'review', :type => :feature do
     end
   end
 
-  describe 'new review page' do
+  describe 'new page' do
     it 'displays a form for a new review' do
       project = create(:project, title: 'my title', description: 'my desc')
 
@@ -25,7 +25,7 @@ describe 'review', :type => :feature do
       expect(page).to have_css('form')
     end
 
-    it 'redirects to the project show page when a review is submitted without content' do
+    it 'redirects to the project show page when a review is submitted' do
       project = create(:project, title: 'my title', description: 'my desc')
 
       visit '/reviews/new.' + project.id.to_s


### PR DESCRIPTION
Add link to create new project on project index page (this link is appearing as the first box on the index page, because putting it in the header bar means that it would appear everywhere in the application, which didn't seem right, but that can be restyled if necessary)
Add project new page form with validation of fields
Reword some test descriptions to be consistent
Remove some extraneous whitespace 