### PR TITLE
Add invited reviewers to project

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,5 +18,6 @@
 //= require url.js
 //= require rating.js
 //= require review.js
+//= require project.js
 //= require tab.js
 //= require_tree .

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -66,4 +66,7 @@ $(document).ready(function () {
                               active_content_id);
   });
 
+  $("#add-invite-link").on("click", function(event) {
+    addInviteField();
+  });
 });

--- a/app/assets/javascripts/project.js
+++ b/app/assets/javascripts/project.js
@@ -1,0 +1,6 @@
+var client = new Client();
+var dom = new Dom();
+
+addInviteField = function() {
+  $('#invites').append($('#new-invite-field').html()) 
+};

--- a/app/assets/javascripts/review.js
+++ b/app/assets/javascripts/review.js
@@ -5,7 +5,7 @@ showNewReviewForm = function(project_id) {
   var callback = function(response) {
     dom.displayPartial("#new-review",
                        response);
-    dom.hideElement("#new-review-box");
+    dom.hideElement("#new-review-link");
   };
   client.ajaxGet("/reviews/new/" + project_id,
                  callback); 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -7,7 +7,7 @@ class ProjectsController < ApplicationController
     elsif current_user == @project.owner
       @user = current_user
       @reviews = @project.reviews.order(updated_at: :desc)
-    elsif @project.get_reviewers.include?(current_user)
+    elsif @project.get_invites.include?(current_user) or @project.get_reviewers.include?(current_user)
       @user = current_user
       @reviews = Review.get_user_owned_reviews(@user,
                                                @project)
@@ -28,9 +28,17 @@ class ProjectsController < ApplicationController
   def create
     project = Project.new(title: project_params[:title],
                           description: project_params[:description])
+    emails = params[:emails]
     if project.save
       ProjectOwner.create(project_id: project.id,
                           user_id: current_user.id)
+      if emails
+        emails.each do |email|
+          user = User.find_or_create_by(email: email)
+          ProjectInvite.create(project_id: project.id,
+                               user_id: user.id)
+        end
+      end
       redirect_to user_path(current_user.id)
     else
       redirect_to new_project_path(user: project_params[:user_id]), { flash: { error: project.get_error_message } }
@@ -61,4 +69,5 @@ class ProjectsController < ApplicationController
   def project_params
     params.require(:project).permit(:title, :description, :user_id)
   end
+
 end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -1,10 +1,17 @@
 class ReviewsController < ApplicationController
 
   def new
-    @project = Project.find(params[:project_id])
-    @review = Review.new
-    if request.xhr?
-      render partial: "reviews/new"
+    if logged_out?
+      redirect_to root_path
+    else
+      @project = Project.find(params[:project_id])
+      @review = Review.new
+      if !@project.get_invites.include?(current_user)
+        redirect_to user_path(current_user.id)
+      elsif request.xhr?
+        render partial: "reviews/new"
+      else
+      end
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,6 +11,7 @@ class UsersController < ApplicationController
       @review = Review.get_random_review(@user)
       @projects = @user.projects.order(updated_at: :desc).all
       @reviews = @user.reviews.order(updated_at: :desc).all
+      @invites = @user.invites.order(updated_at: :desc).all 
     end
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -29,4 +29,10 @@ class Project < ApplicationRecord
                              .select('user_id')
     return User.where(id: user_reviews).all
   end
+
+  def get_invites
+    project_invites = ProjectInvite.where(project_id: id)
+                                   .select('user_id')
+    return User.where(id: project_invites).all
+  end
 end

--- a/app/views/projects/_invite.html.erb
+++ b/app/views/projects/_invite.html.erb
@@ -1,0 +1,1 @@
+<%= email_field_tag 'emails[]', nil, size: 60, class: 'form-input' %>

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -6,21 +6,33 @@
   <% end %>
 </div>
 
-<%= form_for @project do |f| %>
+<%= form_tag("/projects", method: "post") do %>
   <div class='big-box'>
-    <%= f.label :title, "Title:" %>
-    <%= f.text_field :title, size: 60, class: 'form-input' %><br /><br />
-    <%= f.label :description, "Description:" %><br /><br />
-    <%= f.text_area(:description, cols: 90, rows: 16, class: 'form-input' ) %><br />
+    <%= fields_for @project do |f| %>
+      <%= f.label :title, "Title:" %>
+      <%= f.text_field :title, size: 60, class: 'form-input' %><br /><br />
 
-    <%= f.hidden_field :user_id, value: @user.id %>
-    <%= f.submit "Create new project" , class: 'button' %>
-    <%= link_to 'cancel', user_path(@user), class: 'cancel-link' %>
+      <%= f.label :description, "Description:" %><br /><br />
+      <%= f.text_area(:description, cols: 90, rows: 16, class: 'form-input' ) %><br /><br />
+
+      <div class='markdown-key'>
+        <p> This form supports markdown: **bold**, *italics*, _underline_  ~~strikethrough~~, ^(superscript), ==highlight== ```code``` (syntax highlighting supported)</p>
+      </div><br />
+
+      <%= label_tag "emails[]", "Enter email address to invite reviewer:" %><br /><br />
+      <span id="invites">
+        <%= render 'invite' %>
+      </span>
+      <a href='#invites' id='add-invite-link'>+</a>
+      <br /><br />
+
+      <%= f.hidden_field :user_id, value: @user.id %>
+      <%= f.submit "Create new project" , class: 'button' %>
+      <%= link_to 'cancel', user_path(@user), class: 'cancel-link' %>
+    <% end %>
   </div>
 <% end %>
 
-<div class='big-box'>
-  <div class='markdown-key'>
-    <p> This form supports markdown: **bold**, *italics*, _underline_  ~~strikethrough~~, ^(superscript), ==highlight== ```code``` (syntax highlighting supported)</p>
-  </div>
+<div style="display:none" id="new-invite-field">
+  <%= render 'invite', locals: {project: false} %>
 </div>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -18,14 +18,25 @@
 </div>
 <br \>
 
+<% if @project.invites.count > 0 and @user == @project.owner %>
+  <div>
+    <h3>Invited reviewers</h3>
+    <ul>
+      <% @project.invites.each do |invite| %>
+        <li><%= invite.email %></li>
+      <% end %>
+    </ul>
+  </div>
+<br \>
+<% end %>
+
 <div id='new-review' class='load-form'></div>
 
-<% if @reviews.length > 0 %>
-  <% if @user == @project.owner %>
-    <h3>Reviews</h3>
-  <% else %>
-    <h3>Your review</h3>
-  <% end %>
+<% if @user == @project.owner and @project.helpful_reviews_count > 0 %>
+  <h3>Reviews</h3>
+<% end %>
+<% if @project.get_reviewers.include?(current_user) %>
+  <h3>Your review</h3>
 <% end %>
 
 <% if @user != @project.owner %>
@@ -33,7 +44,7 @@
 <% end %>
 
 <% @reviews.each do |review| %>
-  <% if review.visible? or review.user == @user %>
+  <% if (@user == @project.owner and review.visible?) or @user == review.user %>
     <div>
       <div class='bracket-box'>
         <div class='squarebrackets'>

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -23,11 +23,11 @@
 
 <div id='new-rating' class='load-form'></div>
 
-<% if @ratings.length > 0 %>
-  <h3>Ratings</h3>
-<% end %>
-
 <% if @user != @project.owner %>
+  <% if @ratings.length > 0 %>
+    <h3>Ratings</h3>
+  <% end %>
+
   <% if @user != @review.user %>
     <p id='rating-criteria'>Was this review kind, specific, and actionable?</p><br />
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -8,6 +8,7 @@
   <ul class="tabs">
     <li class="active"><a href="#projects">Projects</a></li>
     <li><a href="#reviews">Reviews</a></li>
+    <li><a href="#invites">Invites</a></li>
   </ul>
 
   <div class="tab-content margin" id="projects">
@@ -21,7 +22,7 @@
           <% if project.updated_at != project.created_at %>
             | updated <%= project.updated_at.strftime('%b %d, %Y') %>
           <% end %></p>
-          <p><%= project.helpful_reviews_count %> Review<%if project.helpful_reviews_count > 1%>s<% end %></p>
+          <p><%= project.helpful_reviews_count %> Review<%if project.helpful_reviews_count != 1%>s<% end %></p>
         </div>
       </div>
     <% end %>
@@ -34,6 +35,22 @@
         <div class='squarebrackets'>
           <%= link_to truncate(review.content, length: 170), review_path(review), class: 'bracket-link review-card' %>
               <p><%= review.get_project %> by <%= review.get_project_owner %></p><p></p>
+        </div>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="tab-content margin" id="invites">
+    <h3>Projects You're Invited to Review</h3>
+    <% @invites.each do |invite| %>
+      <div class='bracket-box'>
+        <div class='squarebrackets'>
+          <%= link_to invite.title, invite, class: 'bracket-link project-card' %>
+          <p><%= invite.created_at.strftime('%b %d, %Y') %>
+          <% if invite.updated_at != invite.created_at %>
+            | updated <%= invite.updated_at.strftime('%b %d, %Y') %>
+          <% end %></p>
+          <p><%= invite.helpful_reviews_count %> Review<%if invite.helpful_reviews_count != 1%>s<% end %></p>
         </div>
       </div>
     <% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -56,7 +56,7 @@ thumbs_down = [ 'This is not kind',
                 'This is neither kind nor actionable',
                 'This is neither kind, specific, or actionable' ]
 
-project_count = 30
+project_count = 40
 
 user_names.each do |name|
   User.create(name: name, email: name + '@gmail.com', uid: 'uid' + name)
@@ -65,24 +65,29 @@ end
 User.create(name: 'Nicole Carpenter', email: 'ncarpenter@8thlight.com', uid: '101379786221150376018')
 User.create(name: 'Hana Lee', email: 'hana@8thlight.com', uid: '106812979936097644716')
 
+user_names += ['Nicole Carpenter', 'Hana Lee']
+
 project_count.times do |i|
   title = languages.sample + ' ' + coding_projects.sample
-  description = (greetings.sample + 'I want to invite you to check out my ' + title + '. ' + schmooze.sample  + '. You can check out my repo here: www.github.com/' + user_names.sample + '/' + title.gsub(/\s+/, '-') + '. Thanks in advance for your feedback!')
+  user = user_names.sample
+  description = (greetings.sample + 'I want to invite you to check out my ' + title + '. ' + schmooze.sample  + '. You can check out my repo here: www.github.com/' + user.downcase.gsub(/\s+/, '') + '/' + title.gsub(/\s+/, '-') + '. Thanks in advance for your feedback!')
   Project.create(title: title, description: description)
-  ProjectOwner.create(project_id: i + 1, user_id: rand(User.count) + 1)
+  ProjectOwner.create(project_id: i + 1, user_id: User.find_by(name: user).id)
 end
 
 100.times do
-  ProjectInvite.create(project_id: rand(Project.count) + 1, user_id: rand(User.count) + 1)
+  project = rand(Project.count) + 1
+  user = ((1..User.count).to_a - [Project.find(project).owner]).sample
+  ProjectInvite.find_or_create_by(project_id: project, user_id: user)
 end
 
-50.times do 
+100.times do 
   review = Review.create(content: review_content.sample)
   UserReview.create(user_id: rand(User.count) + 1, review_id: review.id)
   ProjectReview.create(project_id: rand(Project.count) + 1, review_id: review.id)
 end
 
-75.times do
+100.times do
   rand_bool = rand(2)
   if rand_bool == 1
     rating = Rating.create(helpful: true, explanation: thumbs_up.sample)

--- a/spec/controllers/reviews_controller_spec.rb
+++ b/spec/controllers/reviews_controller_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe ReviewsController, :type => :controller do
   describe 'GET /reviews/new' do
     it 'renders the template for the review new page' do
       project = create(:project)
+      invite = create(:user)
+      create(:project_invite, project_id: project.id,
+                              user_id: invite.id)
+      session[:user_id] = invite.id
 
       get :new, params: { project_id: project.id }
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -52,6 +52,16 @@ RSpec.describe UsersController, :type => :controller do
         expect(response.body).to include(review1.content)
         expect(response.body).to include(review2.content)
       end
+
+      it 'displays the projects that the user has been invited to review' do
+        project = create(:project, title: 'Invited to review')
+        create(:project_invite, project_id: project.id, 
+                                user_id: @user.id)
+
+        get :show, params: { id: @user.id }
+
+        expect(response.body).to include(project.title)
+      end
     end
    
     describe 'when logged in as a different user' do 

--- a/spec/integration/rating_spec.rb
+++ b/spec/integration/rating_spec.rb
@@ -6,7 +6,7 @@ describe 'rating', :type => :feature do
       OmniAuth.config.add_mock(:google_oauth2,
                                { uid: 'uidhillaryclinton',
                                  info: { name: 'hillaryclinton',
-                                         email: 'hillaryclinton@email.com' } })
+                                         email: 'hillaryclinton@gmail.com' } })
       @user = User.find_by_name('hillaryclinton')
       @review = create(:review, content: 'Looks good!')
       project = create(:project, title: "Foo", description: "Bar")
@@ -65,6 +65,10 @@ describe 'rating', :type => :feature do
       expect(current_path).to eq('/reviews/' + @review.id.to_s)
       expect(page).to have_no_css('form') 
     end
+
+    after(:each) do
+      visit "/logout"
+    end
   end
 
   describe 'random new page' do
@@ -72,7 +76,7 @@ describe 'rating', :type => :feature do
       OmniAuth.config.add_mock(:google_oauth2,
                                { uid: 'uidhillaryclinton',
                                  info: { name: 'hillaryclinton',
-                                         email: 'hillaryclinton@email.com' } })
+                                         email: 'hillaryclinton@gmail.com' } })
       @user = User.find_by_name('hillaryclinton')
 
       visit '/'
@@ -109,6 +113,10 @@ describe 'rating', :type => :feature do
 
       expect(current_path).to eq('/users/' + @user.id.to_s)
       expect(page).to have_content("Please provide an explanation")
+    end
+
+    after(:each) do
+      visit "/logout"
     end
   end
 end

--- a/spec/integration/user_spec.rb
+++ b/spec/integration/user_spec.rb
@@ -25,10 +25,10 @@ describe 'user', :type => :feature do
       OmniAuth.config.add_mock(:google_oauth2,
                                { uid: 'uidhillaryclinton',
                                  info: { name: 'hillaryclinton',
-                                         email: 'hillaryclinton@email.com' } })
+                                         email: 'hillaryclinton@gmail.com' } })
 
       visit '/'
-     find_button("Sign in with Google").click
+      find_button("Sign in with Google").click
 
       expect(page).to have_link('Sign out')
     end
@@ -39,7 +39,7 @@ describe 'user', :type => :feature do
       OmniAuth.config.add_mock(:google_oauth2,
                                { uid: 'uidhillaryclinton',
                                  info: { name: 'hillaryclinton',
-                                         email: 'hillaryclinton@email.com' } })
+                                         email: 'hillaryclinton@gmail.com' } })
       @user = User.find_by_name('hillaryclinton')
 
       visit "/"
@@ -138,7 +138,7 @@ describe 'user', :type => :feature do
         user = create(:user, name: 'name1', 
                              email: 'name1@example.com',
                              uid: 'uidname1')
-        review = create(:review, content: 'Amazing job')
+        review = create(:review, content: 'Fantabulous')
         create(:user_review, review_id: review.id,
                              user_id: user.id)
 
@@ -186,6 +186,18 @@ describe 'user', :type => :feature do
         visit user_path(id: @user)
 
         expect(page.body.index(review1.content)).to be > page.body.index(review2.content)
+      end
+    end
+
+    describe 'pending reviews tab' do 
+      it 'shows projects for which the user has been invited to review' do
+        project = create(:project, title: 'Java Bowling Game')
+        create(:project_invite, project_id: project.id,
+                                user_id: @user.id)
+
+        visit user_path(id: @user)
+        
+        expect(page).to have_link(project.title)
       end
     end
 

--- a/spec/javascripts/projectSpec.js
+++ b/spec/javascripts/projectSpec.js
@@ -1,0 +1,16 @@
+//= require application
+
+describe("Projects", function() {
+  beforeEach(function() {
+    server = sinon.fakeServer.create();
+  });
+
+  describe("addInviteField()", function() {
+    it("loads a new email field to invite a reviewer", function() {
+      affix("#invites");
+      addInviteField(); 
+       
+      expect($("#invites").html()).toEqual('<input type="email" name="invites[email]">');
+    });
+  });
+});

--- a/spec/javascripts/reviewSpec.js
+++ b/spec/javascripts/reviewSpec.js
@@ -8,7 +8,7 @@ describe("Reviews", function() {
   describe("showNewReviewForm()", function() {
     it("loads new review form and hides container for link to new review", function() {
       affix("#new-review");
-      affix("#new-review-box");
+      affix("#new-review-link");
       server.respondWith("GET",
                          "/reviews/new/1",
                          "form html");
@@ -16,7 +16,7 @@ describe("Reviews", function() {
       server.respond();
 
       expect($("#new-review").html()).toEqual("form html");
-      expect($("#new-review-box").css("display")).toEqual("none");
+      expect($("#new-review-link").css("display")).toEqual("none");
     });
   });
 


### PR DESCRIPTION
* Project new form has field to add email address for invited reviewer
* Project new form has link to dynamically add extra fields for more email addresses
* User show page has tab showing projects where user is invited to review
* Invited reviewer can access project show page and add review
* Invited reviewer cannot view other people's reviews on project show page
* Project owner can view list of invited reviewers on project show page

(Not included:
* Link to dynamically remove email fields
* Editing invited reviewers list
* Sending email after invited reviewers are submitted
* Removing user from invited reviewers list after review is submitted)